### PR TITLE
Ali/add app time

### DIFF
--- a/lib/logstash/filters/google_appengine.rb
+++ b/lib/logstash/filters/google_appengine.rb
@@ -21,9 +21,7 @@ class LogStash::Filters::GoogleAppengine < LogStash::Filters::Base
     payload.delete '@type'
     payload['type'] = event.get('type')
     payload['latencyS'] = to_number(payload['latency'])
-    if payload['pendingTime']
-      payload['pendingTimeS'] = to_number(payload['pendingTime'])
-    end
+    payload['pendingTimeS'] = to_number(payload['pendingTime'])
     lines = payload.delete 'line'
 
     if lines

--- a/lib/logstash/filters/google_appengine.rb
+++ b/lib/logstash/filters/google_appengine.rb
@@ -22,6 +22,7 @@ class LogStash::Filters::GoogleAppengine < LogStash::Filters::Base
     payload['type'] = event.get('type')
     payload['latencyS'] = to_number(payload['latency'])
     payload['pendingTimeS'] = to_number(payload['pendingTime'])
+    payload['appTimeS'] = payload['latencyS'] - payload['pendingTimeS']
     lines = payload.delete 'line'
 
     if lines

--- a/spec/filters/google_appengine_spec.rb
+++ b/spec/filters/google_appengine_spec.rb
@@ -67,6 +67,13 @@ describe LogStash::Filters::GoogleAppengine do
     end
   end
 
+  describe "should calculate appTimeS from latencyS and pendingTimeS" do
+    test_sample = LogStash::Json.load(File.open("spec/filters/log-with-pendingTime.json", "rb").read)
+    sample (test_sample) do
+      insist { subject[0].get("appTimeS") } == 0.779603 - 0.712152958
+    end
+  end
+
 end
 
 

--- a/spec/filters/google_appengine_spec.rb
+++ b/spec/filters/google_appengine_spec.rb
@@ -59,11 +59,11 @@ describe LogStash::Filters::GoogleAppengine do
     end
   end
 
-  describe "should convert missing pendingTime to missing pendingTimeS" do
+  describe "should convert missing pendingTime to pendingTimeS is 0" do
     test_sample = LogStash::Json.load(File.open("spec/filters/log-without-pendingTime.json", "rb").read)
     sample (test_sample) do
       insist { subject[0].get("pendingTime") } == nil
-      insist { subject[0].get("pendingTimeS") } == nil
+      insist { subject[0].get("pendingTimeS") } == 0
     end
   end
 


### PR DESCRIPTION
Added a new field `appTimeS` which is the real amount of request time spent inside our app, minus the AppEngine scaling queue overhead (`latencyS` minus `pendingTimeS`). Side effect of this is that `pendingTimeS` will always be set, even when the source data does not include `pendingTime`. When `pendingTime` is missing, we set `pendingTimeS` to 0.